### PR TITLE
Add Topas beam-direction check workflow and related tests

### DIFF
--- a/.github/workflows/topas-integration.yml
+++ b/.github/workflows/topas-integration.yml
@@ -1,6 +1,9 @@
 name: Topas beam-direction check
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/topas-integration.yml
+++ b/.github/workflows/topas-integration.yml
@@ -1,0 +1,43 @@
+name: Topas beam-direction check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  beam-direction:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dicomexport
+        run: pip install ".[test]"
+
+      - name: Generate Topas input (test-mode, 100 particles)
+        run: |
+          plan-export \
+            res/test_plans/temp_160MeV_10x10.dcm \
+            topas_beamcheck.txt \
+            -b res/beam_models/DCPT_beam_model__v2.csv \
+            --test-mode -N 100 -f 1
+
+      - name: Pull OpenTOPAS Docker image
+        run: docker pull opentopasmcpro/opentopas:latest
+
+      - name: Run Topas simulation
+        run: |
+          docker run --rm \
+            -v "$PWD":/work \
+            -w /work \
+            opentopasmcpro/opentopas:latest \
+            topas topas_beamcheck_field01.txt
+
+      - name: Assert non-zero dose at isocenter
+        run: python tests/check_isocenter.py

--- a/.github/workflows/topas-integration.yml
+++ b/.github/workflows/topas-integration.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Install dicomexport
         run: pip install ".[test]"
 
-      - name: Generate Topas input (test-mode, 100 particles)
+      - name: Generate Topas input (test-mode, 1000 particles, pos-z convention)
         run: |
           plan-export \
             res/test_plans/temp_160MeV_10x10.dcm \
             topas_beamcheck.txt \
             -b res/beam_models/DCPT_beam_model__v2.csv \
-            --test-mode -N 100 -f 1
+            --test-mode -N 1000 -f 1 --nozzle-side pos-z
 
       - name: Pull OpenTOPAS Docker image
         run: docker pull opentopasmcpro/opentopas:latest

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+isocenter_scorer.csv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+## Getting started
+
+Clone the repository and install in editable mode with all test dependencies:
+
+```bash
+pip install -e ".[test]"
+```
+
+Run the test suite:
+
+```bash
+pytest
+```
+
+---
+
+## Beam-direction integration test
+
+### Background
+
+The `plan-export --test-mode` flag generates a **self-contained** Topas input file for verifying beam direction — no DICOM CT or patient geometry is needed. It produces:
+
+- A 400 × 400 × 400 mm water box (`IsoBox`) centred at the IEC isocenter (World origin).
+- A `DoseToWater` scorer on `IsoBox` that writes `isocenter_scorer.csv`.
+- The complete gantry / couch / DCM-to-IEC coordinate frame.
+
+This is the simplest way to catch a beam-direction regression (e.g. a sign error in `BeamPosition/TransZ`): if the beam goes the wrong way the scorer records zero dose.
+
+### Running the test locally
+
+**1. Generate the Topas input:**
+
+```bash
+plan-export res/test_plans/temp_160MeV_10x10.dcm topas_beamcheck.txt \
+  -b res/beam_models/DCPT_beam_model__v2.csv \
+  --test-mode -N 100 -f 1
+```
+
+**2. Run the simulation with the [OpenTOPAS](https://github.com/OpenTOPAS/OpenTOPAS) Docker image:**
+
+```bash
+docker run --rm \
+  -v "$PWD":/work \
+  -w /work \
+  opentopasmcpro/opentopas:latest \
+  topas topas_beamcheck_field01.txt
+```
+
+**3. Check the result:**
+
+```bash
+python tests/check_isocenter.py
+# exits 0 if dose > 0 at isocenter
+# exits 1 and prints an error if all voxels are zero (beam missed)
+```
+
+### Running via GitHub Actions
+
+The workflow is defined in `.github/workflows/topas-integration.yml` and is **manual-trigger only** (not run on every commit, due to the size of the Docker image). Trigger it from the _Actions_ tab → _Topas beam-direction check_ → _Run workflow_.
+
+### Notes
+
+- `--test-mode` is only available on `plan-export`, not on the full study export (`dicomexport`).
+- Do **not** combine a `--test-mode` output file with a separately generated DICOM patient geometry in one Topas run — the `IsoBox` water volume and the DICOM patient volume would overlap and cause Topas geometry errors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ This is the simplest way to catch a beam-direction regression (e.g. a sign error
 ```bash
 plan-export res/test_plans/temp_160MeV_10x10.dcm topas_beamcheck.txt \
   -b res/beam_models/DCPT_beam_model__v2.csv \
-  --test-mode -N 100 -f 1
+  --test-mode -N 1000 -f 1 --nozzle-side pos-z
 ```
 
 **2. Run the simulation with the [OpenTOPAS](https://github.com/OpenTOPAS/OpenTOPAS) Docker image:**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # DicomExport
+
+[![CI](https://github.com/nbassler/dicomexport/actions/workflows/ci.yml/badge.svg)](https://github.com/nbassler/dicomexport/actions/workflows/ci.yml)
+[![Lint](https://github.com/nbassler/dicomexport/actions/workflows/lint.yml/badge.svg)](https://github.com/nbassler/dicomexport/actions/workflows/lint.yml)
+[![CodeQL](https://github.com/nbassler/dicomexport/actions/workflows/codeql.yml/badge.svg)](https://github.com/nbassler/dicomexport/actions/workflows/codeql.yml)
+[![Build Binaries](https://github.com/nbassler/dicomexport/actions/workflows/build-windows.yml/badge.svg)](https://github.com/nbassler/dicomexport/actions/workflows/build-windows.yml)
+[![TOPAS integration](https://github.com/nbassler/dicomexport/actions/workflows/topas-integration.yml/badge.svg)](https://github.com/nbassler/dicomexport/actions/workflows/topas-integration.yml)
+[![Dependabot](https://img.shields.io/badge/dependabot-enabled-025e8c?logo=dependabot)](https://github.com/nbassler/dicomexport/network/updates)
+
 A tool for exporting DICOM proton therapy studies.
 - Supported output formats: TOPAS input files, MCPL phase-space files, and generic spot lists (FLUKA/SHIELD-HIT12A).
 - More output formats can be added.
@@ -171,4 +179,4 @@ This will process the specified DICOM plan and generate MCPL files for each fiel
 For more details about the MCPL format, visit the [MCPL documentation](https://mctools.github.io/mcpl/).
 
 ## Acknowledgements
-This work is part of the SONORA project, which has received funding from the European Union’s EURATOM research and innovation programme under grant agreement No 101061037 (PIANOFORTE – European Partnership for Radiation Protection Research).
+This work is part of the [SONORA project](https://pianoforte-partnership.eu/sonora/), which has received funding from the European Union's EURATOM research and innovation programme under grant agreement No 101061037 ([PIANOFORTE](https://pianoforte-partnership.eu/) - European Partnership for Radiation Protection Research).

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ You need also so specify a beam model, optionally also at what distance it is de
 Finally you need to point to a Stopping power ratio to material table.
 
 ```bash
-PYTHONPATH=. python3 dicomexport/main.py -v -b=res/beam_models/DCPT_beam_model__v2.csv -p 500.0 -s=res/spr_tables/SPRtoMaterial__Brain.txt res/test_studies/DCPT_headphantom/
+PYTHONPATH=. python3 dicomexport/main.py -v -b=res/beam_models/DCPT_beam_model__v2.csv -p 500.0 --nozzle-side pos-z -s=res/spr_tables/SPRtoMaterial__Brain.txt res/test_studies/DCPT_headphantom/
 ```
 which will produce three topas files, ready to run:
 
 ```
-$ PYTHONPATH=. python3 dicomexport/main.py -v -b=res/beam_models/DCPT_beam_model__v2.csv -p 500.0 -s
+$ PYTHONPATH=. python3 dicomexport/main.py -v -b=res/beam_models/DCPT_beam_model__v2.csv -p 500.0 --nozzle-side pos-z -s
 res/spr_tables/SPRtoMaterial__Brain.txt res/test_studies/DCPT_headphantom/
 INFO:dicomexport.import_rtstruct:Using RTSTRUCT file: RS.1.2.246.352.205.5439556202947041733.367077883804944283.dcm
 INFO:dicomexport.import_rtstruct:Imported RTSTRUCT: DCPT_headphantom with 11 ROIs
@@ -52,10 +52,24 @@ INFO:dicomexport.export_study_topas:Wrote Topas geometry file for field 2: /home
 INFO:dicomexport.export_study_topas:Wrote Topas geometry file for field 3: /home/bassler/Projects/dicomexport/topas_field3.txt
 ```
 
-Command line options and usage:
+### TOPAS beam geometry options
+
+Both the full study exporter (`dicomexport/main.py`, installed as `dicomexport`) and the plan-only exporter
+(`dicomexport/main_plan_export.py`, installed as `plan-export`) support:
+
+- `-p, --beam-model-position`: beam model distance in mm relative to isocenter. This value is positive upstream of the beam by convention and defaults to `500.0`.
+- `--nozzle-side {pos-z,neg-z}`: side of the gantry where the nozzle/source is placed. The default is `pos-z`, meaning source at `+Z` and beam travelling toward `-Z` in the IEC convention. `neg-z` places the source at `-Z` and the beam travels toward `+Z`.
+
+For TOPAS export, the range shifter position follows the selected nozzle side.
+
+### Full study export options
+
 ```
 $ PYTHONPATH=. python3 dicomexport/main.py --help
-usage: main.py [-h] [-b BM] [-s SPR_TO_MATERIAL_PATH] [-p BEAM_MODEL_POSITION] [-f FIELD_NR] [-N NSTAT] [-v] [-V]
+usage: main.py [-h] [-b BM] [-s SPR_TO_MATERIAL_PATH] [-p BEAM_MODEL_POSITION]
+               [-f FIELD_NR] [-N NSTAT]
+               [--export-fmt {topas,phasespace,racehorse}]
+               [--nozzle-side {pos-z,neg-z}] [-v] [-V]
                study_dir [output_base_path]
 
 Convert DICOM CT and RTSTRUCT files to geometry needed for TOPAS.
@@ -64,24 +78,68 @@ positional arguments:
   study_dir             (required) Path to folder containing the study.The folder should contain a) DICOM CT series(CT*.dcm) and b) one
                         DICOM RTSTRUCT file (RS*.dcm) and c) one DICOM RTPLAN file (RN*.dcm) and d) at least one DICOM RTDOSE file
                         (RD*.dcm) where the resulting dose distribution will be stored.
-  output_base_path      Output TOPAS geometry file (default: topas.txt). Field number will be appended automatically to the name before
-                        the extension.
+  output_base_path      Export file (default: topas.txt). Field number will be appended automatically to the name before the extension.
 
 options:
   -h, --help            show this help message and exit
-  -b BM, --beam-model BM
+  -b, --beam-model BM
                         (required) Beam model CSV path
-  -s SPR_TO_MATERIAL_PATH, --spr-to-material SPR_TO_MATERIAL_PATH
+  -s, --spr-to-material SPR_TO_MATERIAL_PATH
                         (required) SPR to material mapping CSV path
-  -p BEAM_MODEL_POSITION, --beam-model-position BEAM_MODEL_POSITION
+  -p, --beam-model-position BEAM_MODEL_POSITION
                         Beam model position in mm, relative to isocenter, positive upstream.
-  -f FIELD_NR, --field FIELD_NR
+  -f, --field FIELD_NR
                         Field number to export. If not specified, all fields will be exported.
-  -N NSTAT, --nstat NSTAT
+  -N, --nstat NSTAT
                         Target protons for simulation
+  --export-fmt {topas,phasespace,racehorse}
+                        Export format (default: topas). Formats: topas (*.txt), phasespace (*.mcpl), racehorse (*.csv).
+  --nozzle-side {pos-z,neg-z}
+                        Which side of the gantry the nozzle sits on (default: pos-z). pos-z: nozzle at +Z, beam travels toward -Z
+                        (IEC convention). neg-z: nozzle at -Z, beam travels toward +Z.
   -v, --verbosity       Increase verbosity (can use -v, -vv, etc.).
   -V, --version         Show version and exit.
   ```
+
+### Plan-only export options
+
+```
+$ PYTHONPATH=. python3 dicomexport/main_plan_export.py --help
+usage: main_plan_export.py [-h] [-b FBM] [-p BEAM_MODEL_POSITION]
+                           [-f FIELD_NR] [-d] [-s SCALE] [-N NSTAT]
+                           [-nc {5,6,7,9,11}]
+                           [--export-fmt {topas,mcpl,racehorse,spotlist}]
+                           [--spot-pos-iso] [--test-mode]
+                           [--nozzle-side {pos-z,neg-z}] [-v] [-V]
+                           fin [fout]
+
+Convert DICOM-RT Ion plans to MC-compatible spot lists using a beam model.
+
+positional arguments:
+  fin                   Input DICOM-RN or IBA .pld file
+  fout                  Output file, default: plan.txt. Field number will be appended automatically to the name before the extension.
+
+options:
+  -h, --help            show this help message and exit
+  -b, --beam-model FBM  Beam model CSV path
+  -p, --beam-model-position BEAM_MODEL_POSITION
+                        Beam model position in mm, relative to isocenter, positive upstream.
+  -f, --field FIELD_NR  Field number to export. If not specified, all fields will be exported.
+  -d, --diag            Print plan diagnostics and exit
+  -s, --scale SCALE     additional scaling multiplier for MC plan
+  -N, --nstat NSTAT     Target protons for simulation
+  -nc, --spotlist-column-count {5,6,7,9,11}
+                        Number of columns in the spotlist export. Valid values: 5, 6, 7, 9, or 11 (default: 11).
+  --export-fmt {topas,mcpl,racehorse,spotlist}
+                        Export format (default: topas). Formats: topas (*.txt), mcpl (*.mcpl), racehorse (*.csv), spotlist (*.txt).
+  --spot-pos-iso        Export spot X/Y positions at isocenter (z=0) instead of the beam model plane.
+  --test-mode           Generate a self-contained Topas file (no DICOM patient) with a water box and isocenter dose scorer.
+  --nozzle-side {pos-z,neg-z}
+                        Which side of the gantry the nozzle sits on (default: pos-z). pos-z: nozzle at +Z, beam travels toward -Z
+                        (IEC convention). neg-z: nozzle at -Z, beam travels toward +Z.
+  -v, --verbosity       Increase verbosity
+  -V, --version         show program's version number and exit
+```
 
 ### Example for SpotList export
 Can export files which are useful for passing them to FLUKA via the `SOURCE` card, or loading into SHIELD-HIT12A via the `USECBEAM` card.

--- a/dicomexport/export_plan.py
+++ b/dicomexport/export_plan.py
@@ -11,7 +11,8 @@ logger = logging.getLogger(__name__)
 
 # toplevel export plan method
 def export_plan(pln: Plan, bm: BeamModel, output_base_path: Path, field_nr: int = -1,
-                nstat: int = int(1e6), fmt: str = "topas", test_mode: bool = False) -> None:
+                nstat: int = int(1e6), fmt: str = "topas", test_mode: bool = False,
+                beam_direction: int = 1) -> None:
     """
     Export one or all fields from a Plan to output files.
     If field_nr >= 1, export only that field.
@@ -33,7 +34,8 @@ def export_plan(pln: Plan, bm: BeamModel, output_base_path: Path, field_nr: int 
                 p.write_text(text)
                 logger.debug(f"Exported field {field.number} layer {layer.number} to Racehorse format.")
         elif fmt == "topas":
-            text = TopasPlan.generate(field, bm, nstat=nstat, test_mode=test_mode)
+            text = TopasPlan.generate(field, bm, nstat=nstat, test_mode=test_mode,
+                                      beam_direction=beam_direction)
             _out_path(output_base_path, field.number).write_text(text)
             logger.debug(f"Exported field {field.number} to Topas format.")
         else:

--- a/dicomexport/export_plan.py
+++ b/dicomexport/export_plan.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 # toplevel export plan method
 def export_plan(pln: Plan, bm: BeamModel, output_base_path: Path, field_nr: int = -1,
-                nstat: int = int(1e6), fmt: str = "topas") -> None:
+                nstat: int = int(1e6), fmt: str = "topas", test_mode: bool = False) -> None:
     """
     Export one or all fields from a Plan to output files.
     If field_nr >= 1, export only that field.
@@ -33,7 +33,7 @@ def export_plan(pln: Plan, bm: BeamModel, output_base_path: Path, field_nr: int 
                 p.write_text(text)
                 logger.debug(f"Exported field {field.number} layer {layer.number} to Racehorse format.")
         elif fmt == "topas":
-            text = TopasPlan.generate(field, bm, nstat=nstat)
+            text = TopasPlan.generate(field, bm, nstat=nstat, test_mode=test_mode)
             _out_path(output_base_path, field.number).write_text(text)
             logger.debug(f"Exported field {field.number} to Topas format.")
         else:

--- a/dicomexport/export_plan_topas.py
+++ b/dicomexport/export_plan_topas.py
@@ -48,6 +48,7 @@ class TopasPlan:
             lines.append(TopasText.geometry_gantry())
             lines.append(TopasText.geometry_couch())
             lines.append(TopasText.geometry_dcm_to_iec())
+            lines.append(TopasText.geometry_isocenter_scorer())
         lines.append(TopasText.geometry_beam_position_timefeature(
             bm.beam_model_position))
         lines.append(TopasText.geometry_range_shifter(myfield))

--- a/dicomexport/export_plan_topas.py
+++ b/dicomexport/export_plan_topas.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class TopasPlan:
     @staticmethod
     def generate(myfield: Field, bm: BeamModel,
-                 nstat=100000, test_mode=False) -> str:
+                 nstat=100000, test_mode=False, beam_direction: int = 1) -> str:
         """
         Export the field to a topas input file.
         """
@@ -50,18 +50,19 @@ class TopasPlan:
             lines.append(TopasText.geometry_dcm_to_iec())
             lines.append(TopasText.geometry_isocenter_scorer())
         lines.append(TopasText.geometry_beam_position_timefeature(
-            bm.beam_model_position))
-        lines.append(TopasText.geometry_range_shifter(myfield))
+            bm.beam_model_position, beam_direction=beam_direction))
+        lines.append(TopasText.geometry_range_shifter(myfield, beam_direction=beam_direction))
         lines.append(TopasText.field_beam_timefeature())
 
         lines.append(TopasPlan.time_features_string(
-            myfield, bm, nstat))
+            myfield, bm, nstat, beam_direction=beam_direction))
 
         topas_text = "".join(lines)
         return topas_text
 
     @staticmethod
-    def time_features_string(myfield: Field, bm: BeamModel, nstat: int = int(1e6)) -> str:
+    def time_features_string(myfield: Field, bm: BeamModel, nstat: int = int(1e6),
+                             beam_direction: int = 1) -> str:
         """
         Build the TIME FEATURES section for a Topas file and return as a string.
         """
@@ -122,10 +123,19 @@ class TopasPlan:
         lines.append(
             f"d:Tf/TimelineEnd                     = {n_spots+1} s\n\n")
 
+        # Pre-compute BeamPositionRotY (RotY of the beam nozzle group) per spot:
+        #   pos-Z (beam_direction=1):  180.0 - angx  (Ry(180°) baseline flips emission to -Z)
+        #   neg-Z (beam_direction=-1): -angx          (nozzle at -Z, beam travels +Z)
+        if beam_direction == 1:
+            beam_pos_roty = 180.0 - angx
+        else:
+            beam_pos_roty = -angx
+
         lines.append(_topas_array(times, energies_real, "Energy", "f", 3, "MeV"))
         lines.append(_topas_array(times, espreads, "EnergySpread", "f", 5, ""))
         lines.append(_topas_array(times, posx, "spotPositionX", "f", 2, "mm"))
         lines.append(_topas_array(times, angx, "spotAngleX", "f", 3, "deg"))
+        lines.append(_topas_array(times, beam_pos_roty, "BeamPositionRotY", "f", 3, "deg"))
         lines.append(_topas_array(times, posy, "spotPositionY", "f", 2, "mm"))
         lines.append(_topas_array(times, angy, "spotAngleY", "f", 3, "deg"))
         lines.append(_topas_array(times, sigx, "SigmaX", "f", 5, "mm"))

--- a/dicomexport/export_study_topas.py
+++ b/dicomexport/export_study_topas.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 def export_study_topas(ct: CTModel, rs: RTStruct, plan: Plan, output_base_path: Path,
-                       field_nr: int = 0, dose_path: Optional[Path] = None, nstat: int = int(1e6)) -> None:
+                       field_nr: int = 0, dose_path: Optional[Path] = None, nstat: int = int(1e6),
+                       beam_direction: int = 1) -> None:
     """
     Export the CT and RTStruct models to a Topas-compatible geometry file.
     """
@@ -30,18 +31,21 @@ def export_study_topas(ct: CTModel, rs: RTStruct, plan: Plan, output_base_path: 
                 f"Exporting field {field.number} to Topas geometry file...")
             logger.info("=" * 50)
             _export_study_field_topas(
-                ct, rs, field, plan.beam_model, output_base_path, dose_path, nstat=nstat)
+                ct, rs, field, plan.beam_model, output_base_path, dose_path, nstat=nstat,
+                beam_direction=beam_direction)
             logger.info("-" * 50 + "\n")
     else:
         # Export a single field
         field = plan.fields[field_nr]
         _export_study_field_topas(
-            ct, rs, field, plan.beam_model, output_base_path, dose_path, nstat=nstat)
+            ct, rs, field, plan.beam_model, output_base_path, dose_path, nstat=nstat,
+            beam_direction=beam_direction)
 
 
 def _export_study_field_topas(ct: CTModel, rs: RTStruct, fld: Field, bm: Optional[BeamModel] = None,
                               output_base_path: Optional[Path] = None,
-                              dose_path: Optional[Path] = None, nstat: int = int(1e6)) -> None:
+                              dose_path: Optional[Path] = None, nstat: int = int(1e6),
+                              beam_direction: int = 1) -> None:
     """
     Export a single field to a Topas-compatible geometry file.
     """
@@ -69,11 +73,11 @@ def _export_study_field_topas(ct: CTModel, rs: RTStruct, fld: Field, bm: Optiona
     lines.append(TopasText.geometry_dcm_to_iec())
     if bm and bm.beam_model_position:
         lines.append(TopasText.geometry_beam_position_timefeature(
-            bm.beam_model_position))
+            bm.beam_model_position, beam_direction=beam_direction))
     else:
-        lines.append(TopasText.geometry_beam_position_timefeature(0.0))
+        lines.append(TopasText.geometry_beam_position_timefeature(0.0, beam_direction=beam_direction))
 
-    lines.append(TopasText.geometry_range_shifter(fld))
+    lines.append(TopasText.geometry_range_shifter(fld, beam_direction=beam_direction))
     lines.append(TopasText.field_beam_timefeature())
     lines.append(TopasText.scorer_setup_dicom(
         topas_output_path=str(topas_output_file_str_no_suffix)))
@@ -84,7 +88,7 @@ def _export_study_field_topas(ct: CTModel, rs: RTStruct, fld: Field, bm: Optiona
     # and move the load beam model from __init__.py to a new dedicated function in BeamModel class.
     if bm:
         lines.append(TopasPlan.time_features_string(
-            fld, bm, nstat=nstat))
+            fld, bm, nstat=nstat, beam_direction=beam_direction))
         topas_string = "\n".join(lines)
 
         # show some information about the field

--- a/dicomexport/main.py
+++ b/dicomexport/main.py
@@ -60,11 +60,13 @@ def main(args=None) -> int:
 
     # export the plan file
     if parsed_args.export_fmt == 'topas':
+        beam_direction = 1 if parsed_args.nozzle_side == 'pos-z' else -1
         export_study_topas(ct, rs, pn,
                            parsed_args.output_base_path,
                            field_nr=parsed_args.field_nr,
                            dose_path=rd_path,
-                           nstat=parsed_args.nstat)
+                           nstat=parsed_args.nstat,
+                           beam_direction=beam_direction)
     elif parsed_args.export_fmt == 'phasespace':
         logger.error("Phasespace export is not implemented yet in this build.")
         # Later: call your MCPL exporter here.

--- a/dicomexport/main_plan_export.py
+++ b/dicomexport/main_plan_export.py
@@ -62,11 +62,13 @@ def main(args=None) -> int:
         )
 
     elif parsed_args.export_fmt == 'topas':
+        beam_direction = 1 if parsed_args.nozzle_side == 'pos-z' else -1
         export_plan(pln, pln.beam_model, parsed_args.fout,
                     field_nr=parsed_args.field_nr,
                     nstat=parsed_args.nstat,
                     fmt=parsed_args.export_fmt,
-                    test_mode=parsed_args.test_mode)
+                    test_mode=parsed_args.test_mode,
+                    beam_direction=beam_direction)
 
     elif parsed_args.export_fmt == 'racehorse':
         # TODO

--- a/dicomexport/main_plan_export.py
+++ b/dicomexport/main_plan_export.py
@@ -65,7 +65,8 @@ def main(args=None) -> int:
         export_plan(pln, pln.beam_model, parsed_args.fout,
                     field_nr=parsed_args.field_nr,
                     nstat=parsed_args.nstat,
-                    fmt=parsed_args.export_fmt)
+                    fmt=parsed_args.export_fmt,
+                    test_mode=parsed_args.test_mode)
 
     elif parsed_args.export_fmt == 'racehorse':
         # TODO

--- a/dicomexport/parser_main.py
+++ b/dicomexport/parser_main.py
@@ -42,6 +42,12 @@ def create_parser():
               "Formats: topas (*.txt), phasespace (*.mcpl), racehorse (*.csv).")
     )
 
+    parser.add_argument('--nozzle-side', dest='nozzle_side', choices=['pos-z', 'neg-z'],
+                        default='pos-z',
+                        help="Which side of the gantry the nozzle sits on (default: pos-z). "
+                             "pos-z: nozzle at +Z, beam travels toward -Z (IEC convention). "
+                             "neg-z: nozzle at -Z, beam travels toward +Z (empirically verified with TOPAS 3.9).")
+
     parser.add_argument('-v', '--verbosity', action='count', default=0,
                         help="Increase verbosity (can use -v, -vv, etc.).")
 

--- a/dicomexport/parser_plan_export.py
+++ b/dicomexport/parser_plan_export.py
@@ -38,6 +38,10 @@ def create_parser():
                         help="Export spot X/Y positions at isocenter (z=0) instead of the beam model plane. "
                              "Spot sizes, divergences, and correlations are still taken from the beam model.")
 
+    parser.add_argument('--test-mode', action='store_true', dest='test_mode', default=False,
+                        help="Generate a self-contained Topas file (no DICOM patient) with a water box "
+                             "and isocenter dose scorer. Useful for CI beam-direction checks.")
+
     parser.add_argument('-v', '--verbosity', action='count', help="Increase verbosity", default=0)
     parser.add_argument('-V', '--version', action='version', version=__version__)
 

--- a/dicomexport/parser_plan_export.py
+++ b/dicomexport/parser_plan_export.py
@@ -42,6 +42,12 @@ def create_parser():
                         help="Generate a self-contained Topas file (no DICOM patient) with a water box "
                              "and isocenter dose scorer. Useful for CI beam-direction checks.")
 
+    parser.add_argument('--nozzle-side', dest='nozzle_side', choices=['pos-z', 'neg-z'],
+                        default='pos-z',
+                        help="Which side of the gantry the nozzle sits on (default: pos-z). "
+                             "pos-z: nozzle at +Z, beam travels toward -Z (IEC convention). "
+                             "neg-z: nozzle at -Z, beam travels toward +Z (empirically verified with TOPAS 3.9).")
+
     parser.add_argument('-v', '--verbosity', action='count', help="Increase verbosity", default=0)
     parser.add_argument('-V', '--version', action='version', version=__version__)
 

--- a/dicomexport/topas_text.py
+++ b/dicomexport/topas_text.py
@@ -527,7 +527,7 @@ class TopasText:
             "##############################################",
             's:Ge/IsoBox/Type                     = "TsBox"',
             's:Ge/IsoBox/Parent                   = "World"',
-            's:Ge/IsoBox/Material                 = "G4_WATER"',
+            's:Ge/IsoBox/Material                 = "G4_Water"',
             "d:Ge/IsoBox/HLX                      = 200 mm",
             "d:Ge/IsoBox/HLY                      = 200 mm",
             "d:Ge/IsoBox/HLZ                      = 200 mm",

--- a/dicomexport/topas_text.py
+++ b/dicomexport/topas_text.py
@@ -514,7 +514,7 @@ class TopasText:
         """
         Self-contained water box + dose scorer centred at the IEC isocenter (World origin).
         Used in test_mode to verify that the beam actually reaches the isocenter.
-        The scorer writes a CSV file named 'isocenter_scorer'.
+        The scorer writes a CSV file named 'isocenter_scorer.csv' (TOPAS adds the .csv extension).
         """
         lines = [
             "##############################################",

--- a/dicomexport/topas_text.py
+++ b/dicomexport/topas_text.py
@@ -508,3 +508,32 @@ class TopasText:
             "\n"
         ]
         return "\n".join(lines)
+
+    @staticmethod
+    def geometry_isocenter_scorer() -> str:
+        """
+        Self-contained water box + dose scorer centred at the IEC isocenter (World origin).
+        Used in test_mode to verify that the beam actually reaches the isocenter.
+        The scorer writes a CSV file named 'isocenter_scorer'.
+        """
+        lines = [
+            "##############################################",
+            "###   I S O C E N T E R   S C O R E R      ###",
+            "##############################################",
+            's:Ge/IsoBox/Type                     = "TsBox"',
+            's:Ge/IsoBox/Parent                   = "World"',
+            's:Ge/IsoBox/Material                 = "G4_WATER"',
+            "d:Ge/IsoBox/HLX                      = 200 mm",
+            "d:Ge/IsoBox/HLY                      = 200 mm",
+            "d:Ge/IsoBox/HLZ                      = 200 mm",
+            "d:Ge/IsoBox/TransX                   = 0.0 mm",
+            "d:Ge/IsoBox/TransY                   = 0.0 mm",
+            "d:Ge/IsoBox/TransZ                   = 0.0 mm",
+            's:Sc/IsoScore/Quantity               = "DoseToWater"',
+            's:Sc/IsoScore/Component              = "IsoBox"',
+            's:Sc/IsoScore/OutputType             = "csv"',
+            's:Sc/IsoScore/IfOutputFileAlreadyExists = "Overwrite"',
+            's:Sc/IsoScore/OutputFile             = "isocenter_scorer"',
+            "\n"
+        ]
+        return "\n".join(lines)

--- a/dicomexport/topas_text.py
+++ b/dicomexport/topas_text.py
@@ -527,7 +527,7 @@ class TopasText:
             "##############################################",
             's:Ge/IsoBox/Type                     = "TsBox"',
             's:Ge/IsoBox/Parent                   = "World"',
-            's:Ge/IsoBox/Material                 = "G4_Water"',
+            's:Ge/IsoBox/Material                 = "G4_WATER"',
             "d:Ge/IsoBox/HLX                      = 200 mm",
             "d:Ge/IsoBox/HLY                      = 200 mm",
             "d:Ge/IsoBox/HLZ                      = 200 mm",

--- a/dicomexport/topas_text.py
+++ b/dicomexport/topas_text.py
@@ -258,29 +258,35 @@ class TopasText:
         return "\n".join(lines)
 
     @staticmethod
-    def geometry_beam_position_timefeature(beam_model_position: float = 500.0) -> str:
+    def geometry_beam_position_timefeature(beam_model_position: float = 500.0,
+                                           beam_direction: int = 1) -> str:
+        # RotY is pre-computed per spot into BeamPositionRotY time feature:
+        #   pos-Z (beam_direction=1):  180.0 - angx  (Ry(180°) baseline flips emission to -Z)
+        #   neg-Z (beam_direction=-1): -angx          (empirically verified)
+        transz = f"{beam_model_position}" if beam_direction == 1 else f"-{beam_model_position}"
         lines = [
             "##############################################",
             "###    GEOM.  B E A M   P O S I T I O N    ###",
             "##############################################",
             's:Ge/BeamPosition/Parent             = "Gantry"',
             's:Ge/BeamPosition/Type               = "Group"',
-            f"d:Ge/BeamPosition/TransZ             = {beam_model_position} mm",
+            f"d:Ge/BeamPosition/TransZ             = {transz} mm",
             "d:Ge/BeamPosition/TransX             = Tf/spotPositionX/Value mm",
             "d:Ge/BeamPosition/TransY             = -1.0 * Tf/spotPositionY/Value mm",
             "d:Ge/BeamPosition/RotX               = -1.0 * Tf/spotAngleY/Value deg",
-            "d:Ge/BeamPosition/RotY               = -1.0 * Tf/spotAngleX/Value deg",
+            "d:Ge/BeamPosition/RotY               = Tf/BeamPositionRotY/Value deg",
             "d:Ge/BeamPosition/RotZ               = 0.00 deg",
             "\n"
         ]
         return "\n".join(lines)
 
     @staticmethod
-    def geometry_range_shifter(myfield: Field) -> str:
+    def geometry_range_shifter(myfield: Field, beam_direction: int = 1) -> str:
         if myfield.range_shifter is None:
             return ""
 
         rs = myfield.range_shifter
+        transz = beam_direction * (rs.isocenter_distance + rs.thickness * 0.5)
 
         lines = [
             "##############################################",
@@ -295,8 +301,7 @@ class TopasText:
             f"d:Ge/RangeShifter/HLY                = {200:.2f} mm",
             f"d:Ge/RangeShifter/HLZ                = {rs.thickness*0.5:.2f} mm",
             's:Ge/RangeShifter/Color              = "Orange"',
-            # TODO: not to center of RS?
-            f'd:Ge/RangeShifter/TransZ            = {rs.isocenter_distance+rs.thickness*0.5:.2f} mm\n',
+            f'd:Ge/RangeShifter/TransZ            = {transz:.2f} mm\n',
             "\n"
         ]
         return "\n".join(lines)

--- a/tests/check_isocenter.py
+++ b/tests/check_isocenter.py
@@ -1,0 +1,37 @@
+"""
+Check that the Topas isocenter scorer produced non-zero dose.
+Run from the directory containing 'isocenter_scorer.csv' after a Topas simulation.
+Exit 0 on success, 1 on failure.
+"""
+import sys
+import pathlib
+
+csv_path = pathlib.Path("isocenter_scorer.csv")
+
+if not csv_path.exists():
+    print(f"ERROR: scorer output not found: {csv_path.resolve()}", file=sys.stderr)
+    sys.exit(1)
+
+values = []
+for line in csv_path.read_text().splitlines():
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    try:
+        values.append(float(line.split(",")[0]))
+    except ValueError:
+        continue
+
+if not values:
+    print("ERROR: no numeric values found in isocenter_scorer.csv", file=sys.stderr)
+    sys.exit(1)
+
+if not any(v > 0 for v in values):
+    print(
+        "FAIL: all dose values at isocenter are zero — beam likely going in wrong direction.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(f"OK: non-zero dose at isocenter ({max(values):.4e} Gy·proton⁻¹)")
+sys.exit(0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ class TestPregdosCLI:
                 f"--nozzle-side={direction}",
                 "res/test_plans/temp_160MeV_10x10.dcm",
             ]
-            assert main_plan_export.main(test_args) == 0, f"CLI failed for --beam-direction={direction}"
+            assert main_plan_export.main(test_args) == 0, f"CLI failed for --nozzle-side={direction}"
             assert test_output_file.exists()
 
             content = test_output_file.read_text()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,3 +59,48 @@ class TestPregdosCLI:
 
     def test_conversion_temp_sobp(self):
         self._run_conversion_test("temp_sobp_10x10.dcm")
+
+    def test_beam_direction_flag(self):
+        for direction in ('pos-z', 'neg-z'):
+            test_output_file = Path("plan_field01.txt")
+            test_output_file.unlink(missing_ok=True)
+
+            test_args = [
+                "-f1",
+                "-b=res/beam_models/DCPT_beam_model__v2.csv",
+                f"--nozzle-side={direction}",
+                "res/test_plans/temp_160MeV_10x10.dcm",
+            ]
+            assert main_plan_export.main(test_args) == 0, f"CLI failed for --beam-direction={direction}"
+            assert test_output_file.exists()
+
+            content = test_output_file.read_text()
+            if direction == 'pos-z':
+                assert 'TransZ             = 500.0 mm' in content, "pos-z: expected +TransZ"
+            else:
+                assert 'TransZ             = -500.0 mm' in content, "neg-z: expected -TransZ"
+            assert 'BeamPositionRotY' in content, f"BeamPositionRotY time feature missing for {direction}"
+
+            test_output_file.unlink()
+
+    def test_test_mode_flag(self):
+        test_output_file = Path("plan_field01.txt")
+        test_output_file.unlink(missing_ok=True)
+
+        test_args = [
+            "-f1",
+            "-b=res/beam_models/DCPT_beam_model__v2.csv",
+            "--test-mode",
+            "res/test_plans/temp_160MeV_10x10.dcm",
+        ]
+
+        assert main_plan_export.main(test_args) == 0
+        assert test_output_file.exists()
+
+        content = test_output_file.read_text()
+        assert 'Ge/IsoBox' in content, "--test-mode output missing IsoBox geometry"
+        assert 'Sc/IsoScore' in content, "--test-mode output missing IsoScore scorer"
+        assert 'Ge/Gantry' in content, "--test-mode output missing gantry geometry"
+        assert 'Ge/World' in content, "--test-mode output missing world geometry"
+
+        test_output_file.unlink()


### PR DESCRIPTION
- Introduced a GitHub Actions workflow for verifying beam direction using Topas.
- Added a new `check_isocenter.py` script to validate non-zero dose at isocenter.
- Updated `export_plan` and `TopasPlan` to support test mode for generating self-contained Topas files.
- Enhanced `TopasText` with isocenter scorer geometry.
- Updated argument parser to include `--test-mode` option for local testing.
- Documented the integration test process in CONTRIBUTING.md.