### PR TITLE
Fix MCPL Twiss correlation sign; add IEC/rotx180 frame option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ usage: main_plan_export.py [-h] [-b FBM] [-p BEAM_MODEL_POSITION]
                            [-nc {5,6,7,9,11}]
                            [--export-fmt {topas,mcpl,racehorse,spotlist}]
                            [--spot-pos-iso] [--test-mode]
+                           [--mcpl-frame {iec,rotx180}]
                            [--nozzle-side {pos-z,neg-z}] [-v] [-V]
                            fin [fout]
 
@@ -145,6 +146,11 @@ options:
                         Export format (default: topas). Formats: topas (*.txt), mcpl (*.mcpl), racehorse (*.csv), spotlist (*.txt).
   --spot-pos-iso        Export spot X/Y positions at isocenter (z=0) instead of the beam model plane.
   --test-mode           Generate a self-contained Topas file (no DICOM patient) with a water box and isocenter dose scorer.
+  --mcpl-frame {iec,rotx180}
+                        Coordinate frame for MCPL phase-space output (default: iec). iec is the canonical IEC 61217
+                        gantry/nozzle frame (source plane at +D, beam travels toward -Z, isocenter at origin). rotx180
+                        rigidly rotates the beam 180 deg about X so it travels toward +Z (source at -D), which flips the
+                        sign of Y; use it for downstream codes that expect a +Z-forward beam. Only applies to MCPL export.
   --nozzle-side {pos-z,neg-z}
                         Which side of the gantry-local Z axis the nozzle sits on (default: neg-z). neg-z reproduces IEC 61217: at
                         gantry 0 the beam enters an HFS patient from the anterior side (verified against OpenTOPAS 4.2.3, issue
@@ -178,7 +184,25 @@ Written 1000000/1000000 particles (100.0%)
 
 This will process the specified DICOM plan and generate MCPL files for each field.
 
+#### Coordinate frame
 
+The MCPL phase space is **frame-relative (pre-gantry)**: no gantry or couch rotation is
+applied, and the particles are emitted in the beam's own frame. The receiving Monte Carlo
+is expected to place the phase space at the nozzle and apply the gantry transform. Because
+of this, `--nozzle-side` does not apply to MCPL export.
+
+By default (`--mcpl-frame iec`) the frame is the canonical **IEC 61217** gantry/nozzle
+frame:
+
+- axes: `X = Xg`, `Y = Yg`, `Z = Zg`;
+- the source plane is at `+D` (the beam-model position, upstream of isocenter);
+- the beam travels toward **−Z**;
+- the isocenter is at the origin.
+
+`--mcpl-frame rotx180` rigidly rotates the whole phase space 180° about X, so the beam
+travels toward **+Z** with the source at `−D`. A proper rotation cannot reverse Z alone, so
+this **flips the sign of Y**; it preserves all beam optics. Use it for downstream codes that
+expect a +Z-forward beam.
 
 For more details about the MCPL format, visit the [MCPL documentation](https://mctools.github.io/mcpl/).
 

--- a/dicomexport/export_mcpl.py
+++ b/dicomexport/export_mcpl.py
@@ -400,11 +400,12 @@ def _sample_mcpl_buffer_fused(
         t1 = sampler.t1[idx]
         t2 = sampler.t2[idx]
 
-        # Offset the position in the LOCAL transverse basis (t1/t2), matching the angular
-        # offsets below, so the position-angle correlation is direction-independent (#72).
+        # Offset the x/y position in the local transverse basis (t1/t2), matching the
+        # angular offsets below, so the position-angle correlation is direction-independent
+        # (#72). zg stays on the fixed source plane so the phase space remains planar at +D.
         xg = float(sampler.xbm[idx] + x_local * t1[0] + y_local * t2[0])
         yg = float(sampler.ybm[idx] + x_local * t1[1] + y_local * t2[1])
-        zg = float(z_plane + x_local * t1[2] + y_local * t2[2])
+        zg = z_plane
 
         vx = float(v0[0] + xprim * t1[0] + yprim * t2[0])
         vy = float(v0[1] + xprim * t1[1] + yprim * t2[1])
@@ -493,14 +494,15 @@ def _sample_mcpl_buffer_fused_numpy(
     y_local = Ly[:, 0, 0] * z2
     yprim = Ly[:, 1, 0] * z2 + Ly[:, 1, 1] * z3
 
-    # --- positions at the beam-model plane, offset in the LOCAL transverse basis ---
-    # The transverse position offsets must be applied in the SAME frame (t1/t2) as the
-    # angular offsets below. Adding them in global x/y instead inverts the position-angle
-    # (Twiss) correlation whenever t1/t2 flip sign relative to the global axes -- which
-    # they do for the -Z beam direction (t1 = -x_hat), breaking the X plane only (#72).
+    # --- positions at the fixed beam-model plane (z = z_plane), x/y in the local basis ---
+    # The transverse x/y offsets must use the SAME frame (t1/t2) as the angular offsets
+    # below; applying them in global x/y instead inverts the position-angle (Twiss)
+    # correlation whenever t1/t2 flip sign relative to the global axes -- which they do for
+    # the -Z beam direction (t1 = -x_hat), breaking the X plane only (#72). zg is pinned to
+    # the source plane so the phase space stays planar at +D (per the docs/logs framing).
     xg = (xbm + x_local * t1[:, 0] + y_local * t2[:, 0]) * np.float32(0.1)   # mm -> cm
     yg = (ybm + x_local * t1[:, 1] + y_local * t2[:, 1]) * np.float32(0.1)
-    zg = (z_plane + x_local * t1[:, 2] + y_local * t2[:, 2]) * np.float32(0.1)
+    zg = np.full(n, z_plane * np.float32(0.1), dtype=np.float32)
 
     # --- directions: v = v0 + xprim*t1 + yprim*t2, then normalize ---
     # compute components (all float32)

--- a/dicomexport/export_mcpl.py
+++ b/dicomexport/export_mcpl.py
@@ -77,6 +77,7 @@ def generate_mcpl_file(
     num_primaries: int = int(1e7),  # default 10 million particles to generate
     buffer_size: int = 1 << 20,  # approx 1 million particles for buffered writes
     rng_seed: int | None = None,
+    rot180x: bool = False,
 ) -> None:
     """
     Generate an MCPL (Monte Carlo Particle List) file for a given treatment plan.
@@ -101,6 +102,12 @@ def generate_mcpl_file(
             particles (1 << 20).
         rng_seed (int | None, optional): The seed for the random number generator.
             If None, a random seed will be used. Defaults to None.
+        rot180x (bool, optional): If False (default), particles are emitted in the
+            canonical IEC 61217 gantry/nozzle frame: source plane at +D, beam travelling
+            toward -Z, isocenter at the origin. If True, the whole phase space is rigidly
+            rotated 180 deg about X so the beam travels toward +Z (source at -D); this
+            necessarily flips the sign of Y. Use it for downstream codes that expect a
+            +Z-forward beam. It is a rigid rotation and preserves all beam optics.
 
     Returns:
         None
@@ -118,6 +125,11 @@ def generate_mcpl_file(
 
     rng = np.random.default_rng(rng_seed)
     header = _mcpl_header(num_primaries)
+
+    if rot180x:
+        logger.info("MCPL frame: rotx180 -- beam travels toward +Z (source at -D), Y sign flipped.")
+    else:
+        logger.info("MCPL frame: iec -- beam travels toward -Z (source at +D), isocenter at origin.")
 
     fields = plan.fields if field_list is None else [plan.fields[i - 1] for i in field_list]
 
@@ -145,7 +157,7 @@ def generate_mcpl_file(
                 n = min(buffer_size, num_primaries - wrote_count)
                 t0 = time.perf_counter()
                 # buf = _sample_mcpl_buffer_fused(sampler, cache, n, rng=rng)
-                buf = _sample_mcpl_buffer_fused_numpy(sampler, cache, n, rng=rng)
+                buf = _sample_mcpl_buffer_fused_numpy(sampler, cache, n, rng=rng, rot180x=rot180x)
                 t1 = time.perf_counter()
                 f.write(buf)
                 t2 = time.perf_counter()
@@ -347,6 +359,7 @@ def _sample_mcpl_buffer_fused(
     *,
     rng: np.random.Generator,
     pdg: int = PDG_PROTON,
+    rot180x: bool = False,
 ) -> bytearray:
     """
     MCPL buffer generation with fused loop for better CPU cache usage.
@@ -383,13 +396,15 @@ def _sample_mcpl_buffer_fused(
         y_local = Ly[0, 0] * z2
         yprim = Ly[1, 0] * z2 + Ly[1, 1] * z3  # yprim = dy/dz
 
-        xg = float(sampler.xbm[idx] + x_local)
-        yg = float(sampler.ybm[idx] + y_local)
-        zg = z_plane
-
         v0 = sampler.v0[idx]
         t1 = sampler.t1[idx]
         t2 = sampler.t2[idx]
+
+        # Offset the position in the LOCAL transverse basis (t1/t2), matching the angular
+        # offsets below, so the position-angle correlation is direction-independent (#72).
+        xg = float(sampler.xbm[idx] + x_local * t1[0] + y_local * t2[0])
+        yg = float(sampler.ybm[idx] + x_local * t1[1] + y_local * t2[1])
+        zg = float(z_plane + x_local * t1[2] + y_local * t2[2])
 
         vx = float(v0[0] + xprim * t1[0] + yprim * t2[0])
         vy = float(v0[1] + xprim * t1[1] + yprim * t2[1])
@@ -399,6 +414,13 @@ def _sample_mcpl_buffer_fused(
         vx *= invn
         vy *= invn
         vz *= invn
+
+        if rot180x:
+            # Rigid 180-deg rotation about X (see numpy path / #71): +Z travel, Y flipped.
+            yg = -yg
+            zg = -zg
+            vy = -vy
+            vz = -vz
 
         Emean = float(sampler.Emean[k])
         Esig = float(sampler.Esig[k])
@@ -427,6 +449,7 @@ def _sample_mcpl_buffer_fused_numpy(
     *,
     rng: np.random.Generator,
     pdg: int = PDG_PROTON,
+    rot180x: bool = False,
 ) -> bytes:
     """
     Vectorized MCPL buffer generation (pure NumPy).
@@ -470,10 +493,14 @@ def _sample_mcpl_buffer_fused_numpy(
     y_local = Ly[:, 0, 0] * z2
     yprim = Ly[:, 1, 0] * z2 + Ly[:, 1, 1] * z3
 
-    # --- positions at the fixed plane z = z_plane (global x/y) ---
-    xg = (xbm + x_local) * np.float32(0.1)   # mm -> cm
-    yg = (ybm + y_local) * np.float32(0.1)
-    zg = np.full(n, z_plane * np.float32(0.1), dtype=np.float32)
+    # --- positions at the beam-model plane, offset in the LOCAL transverse basis ---
+    # The transverse position offsets must be applied in the SAME frame (t1/t2) as the
+    # angular offsets below. Adding them in global x/y instead inverts the position-angle
+    # (Twiss) correlation whenever t1/t2 flip sign relative to the global axes -- which
+    # they do for the -Z beam direction (t1 = -x_hat), breaking the X plane only (#72).
+    xg = (xbm + x_local * t1[:, 0] + y_local * t2[:, 0]) * np.float32(0.1)   # mm -> cm
+    yg = (ybm + x_local * t1[:, 1] + y_local * t2[:, 1]) * np.float32(0.1)
+    zg = (z_plane + x_local * t1[:, 2] + y_local * t2[:, 2]) * np.float32(0.1)
 
     # --- directions: v = v0 + xprim*t1 + yprim*t2, then normalize ---
     # compute components (all float32)
@@ -485,6 +512,15 @@ def _sample_mcpl_buffer_fused_numpy(
     vx *= invn
     vy *= invn
     vz *= invn
+
+    if rot180x:
+        # Rigid 180-deg rotation about X: (x,y,z)->(x,-y,-z), (vx,vy,vz)->(vx,-vy,-vz).
+        # Reverses the beam to +Z travel for downstream codes that expect it; being a
+        # proper rotation it preserves all beam optics (#71). Y sign is flipped.
+        yg = -yg
+        zg = -zg
+        vy = -vy
+        vz = -vz
 
     # --- energy sampling ---
     Emean = sampler.Emean[k]

--- a/dicomexport/main_plan_export.py
+++ b/dicomexport/main_plan_export.py
@@ -51,6 +51,10 @@ def main(args=None) -> int:
 
     logger.debug("Exporting plan format...")
     if parsed_args.export_fmt == 'mcpl':
+        if parsed_args.nozzle_side != 'neg-z':
+            logger.info(
+                "--nozzle-side does not apply to MCPL export (the phase space is "
+                "frame-relative / pre-gantry). Use --mcpl-frame to choose the beam frame.")
         generate_mcpl_file(
             pln,
             pln.beam_model,
@@ -58,7 +62,8 @@ def main(args=None) -> int:
             field_list=[parsed_args.field_nr]
             if parsed_args.field_nr > 0 else None,
             num_primaries=parsed_args.nstat,
-            rng_seed=42
+            rng_seed=42,
+            rot180x=(parsed_args.mcpl_frame == 'rotx180'),
         )
 
     elif parsed_args.export_fmt == 'topas':

--- a/dicomexport/parser_plan_export.py
+++ b/dicomexport/parser_plan_export.py
@@ -44,6 +44,17 @@ def create_parser():
                         help="Generate a self-contained Topas file (no DICOM patient) with a water box "
                              "and isocenter dose scorer. Useful for CI beam-direction checks.")
 
+    parser.add_argument('--mcpl-frame', dest='mcpl_frame', choices=['iec', 'rotx180'],
+                        default='iec',
+                        help="Coordinate frame for MCPL phase-space output (default: iec). "
+                             "iec: canonical IEC 61217 gantry/nozzle frame -- source plane at +D, "
+                             "beam travels toward -Z, isocenter at origin, pre-gantry (the receiving "
+                             "MC applies the gantry rotation). rotx180: the same beam rigidly rotated "
+                             "180 deg about X, i.e. beam travels toward +Z with the source at -D; this "
+                             "flips the sign of Y (a proper rotation cannot reverse Z alone). Use "
+                             "rotx180 for downstream codes that expect a +Z-forward beam. Only applies "
+                             "to MCPL export.")
+
     parser.add_argument('--nozzle-side', dest='nozzle_side', choices=['pos-z', 'neg-z'],
                         default='neg-z',
                         help="Which side of the gantry-local Z axis the nozzle sits on (default: neg-z). "

--- a/tests/test_mcpl_correlation.py
+++ b/tests/test_mcpl_correlation.py
@@ -1,0 +1,157 @@
+"""
+Regression tests for the MCPL phase-space position-angle (Twiss) correlation.
+
+Guards against issue #72: the transverse position offsets used to be applied in the
+global x/y axes while the angular offsets were applied in the local beam basis (t1/t2).
+For the -Z beam direction the local basis has t1 = -x_hat, which inverted the X-plane
+position-angle correlation only -- so a symmetric focusing beam model converged in Y but
+diverged in X. The fix applies the position offsets in the same t1/t2 basis as the angles.
+"""
+
+import numpy as np
+import pytest
+
+from dicomexport.export_mcpl import (
+    FieldSampler,
+    BeamCache,
+    _make_transverse_basis_from_v,
+    _chol2_psd,
+    _sample_mcpl_buffer_fused_numpy,
+    _sample_mcpl_buffer_fused,
+)
+
+_REC_DTYPE = np.dtype([
+    ("x", "<f4"), ("y", "<f4"), ("z", "<f4"),
+    ("fp1", "<f4"), ("fp2", "<f4"), ("ekin_signed", "<f4"),
+    ("time", "<f4"), ("pdg", "<i4"),
+])
+
+
+def _unpack_dir(fp1, fp2, ek):
+    """Invert the adaptive-projection packing used by export_mcpl."""
+    fp1 = np.asarray(fp1, dtype=np.float64)
+    fp2 = np.asarray(fp2, dtype=np.float64)
+    ek = np.asarray(ek, dtype=np.float64)
+    ux = np.empty_like(fp1)
+    uy = np.empty_like(fp1)
+    uz = np.empty_like(fp1)
+
+    m1 = np.abs(fp1) > 1.0                    # fp1 = 1/uz  (x dominant)
+    m2 = (~m1) & (np.abs(fp2) > 1.0)          # fp2 = 1/uz  (y dominant)
+    m0 = ~(m1 | m2)                           # fp1=ux, fp2=uy (z dominant)
+
+    ux[m0] = fp1[m0]
+    uy[m0] = fp2[m0]
+    uz[m0] = np.sqrt(np.maximum(0.0, 1.0 - fp1[m0]**2 - fp2[m0]**2)) * np.sign(ek[m0])
+
+    uz[m1] = 1.0 / fp1[m1]
+    uy[m1] = fp2[m1]
+    ux[m1] = np.sqrt(np.maximum(0.0, 1.0 - uy[m1]**2 - uz[m1]**2)) * np.sign(ek[m1])
+
+    uz[m2] = 1.0 / fp2[m2]
+    ux[m2] = fp1[m2]
+    uy[m2] = np.sqrt(np.maximum(0.0, 1.0 - ux[m2]**2 - uz[m2]**2)) * np.sign(ek[m2])
+
+    return ux, uy, uz
+
+
+def _symmetric_focusing_sampler(rho=-0.8, sx=3.0, sy=3.0, divx=0.006, divy=0.006,
+                                z_plane=500.0):
+    """A single on-axis spot with identical, focusing Twiss in X and Y."""
+    v0 = np.array([0.0, 0.0, -1.0], dtype=np.float32)
+    t1, t2 = _make_transverse_basis_from_v(v0)
+
+    sampler = FieldSampler(
+        idxE=np.array([0], dtype=np.uint16),
+        cum_n=np.array([1.0], dtype=np.float64),
+        total_n=1.0,
+        xbm=np.array([0.0], dtype=np.float32),
+        ybm=np.array([0.0], dtype=np.float32),
+        v0=v0.reshape(1, 3),
+        t1=np.asarray(t1, dtype=np.float32).reshape(1, 3),
+        t2=np.asarray(t2, dtype=np.float32).reshape(1, 3),
+        z_plane=z_plane,
+        Enom=np.array([100.0], dtype=np.float32),
+        Emean=np.array([100.0], dtype=np.float32),
+        Esig=np.array([1.0], dtype=np.float32),
+    )
+    Lx = _chol2_psd(sx * sx, divx * divx, rho * sx * divx).astype(np.float32)
+    Ly = _chol2_psd(sy * sy, divy * divy, rho * sy * divy).astype(np.float32)
+    cache = BeamCache(Lx=Lx.reshape(1, 2, 2), Ly=Ly.reshape(1, 2, 2))
+    return sampler, cache
+
+
+def _drift_to_isocenter(buf):
+    """Decode a record buffer and drift every particle from its plane to z=0."""
+    rec = np.frombuffer(buf, dtype=_REC_DTYPE)
+    x, y, z = rec["x"].astype(np.float64), rec["y"].astype(np.float64), rec["z"].astype(np.float64)
+    ux, uy, uz = _unpack_dir(rec["fp1"], rec["fp2"], rec["ekin_signed"])
+    t = (0.0 - z) / uz
+    return x, y, x + t * ux, y + t * uy
+
+
+def test_symmetric_beam_converges_symmetrically():
+    """A symmetric focusing beam model must converge equally in X and Y (issue #72)."""
+    sampler, cache = _symmetric_focusing_sampler()
+    rng = np.random.default_rng(0)
+    buf = _sample_mcpl_buffer_fused_numpy(sampler, cache, 200_000, rng=rng)
+    x0, y0, xi, yi = _drift_to_isocenter(buf)
+
+    sx_plane, sy_plane = x0.std(), y0.std()
+    sx_iso, sy_iso = xi.std(), yi.std()
+
+    # Both planes focus (a negative upstream correlation converges downstream)...
+    assert sx_iso < sx_plane, f"X should converge: {sx_plane:.3f} -> {sx_iso:.3f} mm"
+    assert sy_iso < sy_plane, f"Y should converge: {sy_plane:.3f} -> {sy_iso:.3f} mm"
+    # ...and, being symmetric, focus by the same amount.
+    assert sx_iso == pytest.approx(sy_iso, rel=0.03)
+
+
+def _decode(buf):
+    rec = np.frombuffer(buf, dtype=_REC_DTYPE)
+    ux, uy, uz = _unpack_dir(rec["fp1"], rec["fp2"], rec["ekin_signed"])
+    return dict(x=rec["x"].astype(np.float64), y=rec["y"].astype(np.float64),
+                z=rec["z"].astype(np.float64), ux=ux, uy=uy, uz=uz)
+
+
+def test_rotx180_is_rigid_rotation():
+    """rotx180 must flip the beam to +Z travel and Y sign, preserving beam optics (#71)."""
+    sampler, cache = _symmetric_focusing_sampler()
+    a = _decode(_sample_mcpl_buffer_fused_numpy(
+        sampler, cache, 100_000, rng=np.random.default_rng(7), rot180x=False))
+    b = _decode(_sample_mcpl_buffer_fused_numpy(
+        sampler, cache, 100_000, rng=np.random.default_rng(7), rot180x=True))
+
+    # Same RNG seed -> identical underlying draws, then a deterministic 180-deg-about-X:
+    # (x,y,z)->(x,-y,-z) and (ux,uy,uz)->(ux,-uy,-uz).
+    assert np.allclose(b["x"], a["x"])
+    assert np.allclose(b["y"], -a["y"])
+    assert np.allclose(b["z"], -a["z"])
+    assert np.allclose(b["ux"], a["ux"], atol=1e-6)
+    assert np.allclose(b["uy"], -a["uy"], atol=1e-6)
+    assert np.allclose(b["uz"], -a["uz"], atol=1e-6)
+
+    # Beam now travels toward +Z from a source at -D.
+    assert b["uz"].mean() > 0.99
+    assert b["z"].mean() == pytest.approx(-a["z"].mean(), rel=1e-6)
+
+    # Optics preserved: drift to isocenter (z=0) still converges by the same amount.
+    t = (0.0 - b["z"]) / b["uz"]
+    xi, yi = b["x"] + t * b["ux"], b["y"] + t * b["uy"]
+    assert xi.std() < b["x"].std()
+    assert yi.std() < b["y"].std()
+    assert xi.std() == pytest.approx(yi.std(), rel=0.03)
+
+
+def test_scalar_and_numpy_paths_agree():
+    """The reference scalar path must reproduce the vectorized path's behaviour."""
+    sampler, cache = _symmetric_focusing_sampler()
+    x0n, y0n, xin, yin = _drift_to_isocenter(
+        _sample_mcpl_buffer_fused_numpy(sampler, cache, 100_000, rng=np.random.default_rng(1)))
+    x0s, y0s, xis, yis = _drift_to_isocenter(
+        _sample_mcpl_buffer_fused(sampler, cache, 100_000, rng=np.random.default_rng(1)))
+
+    # Same statistical convergence in both implementations (independent RNG draws).
+    assert xin.std() == pytest.approx(xis.std(), rel=0.05)
+    assert yin.std() == pytest.approx(yis.std(), rel=0.05)
+    assert xis.std() < x0s.std()


### PR DESCRIPTION
MCPL export applied transverse position offsets in the global x/y axes while the divergence angles were applied in the local beam basis (t1/t2). For the -Z beam direction t1 = -x_hat, which inverted the X-plane position-angle correlation only: a symmetric focusing beam model converged in Y but diverged in X (wrong, dose-relevant beam optics for real beam models). Apply the position offsets in the same t1/t2 basis as the angles, so the phase space is fully frame-relative and direction-independent. The TOPAS writer is unaffected -- it delegates to TOPAS's native Emittance/BiGaussian source, which samples position and angle in one consistent local frame.

Also document the MCPL output frame and add --mcpl-frame {iec,rotx180}: iec (default, unchanged behaviour) is the canonical IEC 61217 gantry/nozzle frame -- source plane at +D, beam toward -Z, isocenter at origin, pre-gantry. rotx180 rigidly rotates the phase space 180 deg about X for downstream codes that expect a +Z-forward beam (source at -D), which flips the sign of Y and preserves all beam optics. --nozzle-side does not apply to MCPL and now logs a note.

Adds tests/test_mcpl_correlation.py: symmetric-convergence regression (guards the #72 inversion), rigid-rotation check for rotx180, and scalar/numpy parity. Verified end-to-end with the mcpl reader (iec: source +500 mm, uz~-1; rotx180: source -500 mm, uz~+1).

Closes #72
Closes #71